### PR TITLE
Allow higher PHPUnit versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "laravel/framework": ">=5.1"
     },
     "require-dev": {
-        "phpunit/phpunit" : "^5.0||^6.0||^7.0",
+        "phpunit/phpunit" : "^5.0||^6.0||^7.0||^8.0||^9.0",
         "orchestra/testbench": "~3.0",
         "mockery/mockery": "~0.9||~1.0"
     },


### PR DESCRIPTION
Laravel 8 is now at PHPUnit version 9.